### PR TITLE
Heading Links and Formatting

### DIFF
--- a/TA coding 101.md
+++ b/TA coding 101.md
@@ -1,17 +1,17 @@
 TA coding 101
 
-
-Intro [](#intro)
+<a id="intro"></a>
+Intro
 =====
 
 This document is intended as a reference for our shared coding work. It's an attempt to balance the need for consistency and standardization with individual styles and ownership.  
 
-This is not exactly a traditional 'coding standards' document: things like where to put your commas are really a problem for machines, not people. See [Coding Standards](#CodingStandards) below for details, but keep in mind that formatting is the least interesting part of the problem set.  
+This is not exactly a traditional 'coding standards' document: things like where to put your commas are really a problem for machines, not people. See [Coding Standards](#coding-standards) below for details, but keep in mind that formatting is the least interesting part of the problem set.  
 
 It's also not about rules like _use this language feature_, or _use this paradigm_. There are some rules of thumb here, but this doc is not a code cookbook.  It is intended to help us collectively think about how our work and our code fits together. 
 
-
-Know where we're at
+<a id="know-where"></a>
+Know Where We're At
 ===================
 
 The first and most important principle for our code is to know what _kind_ of code it's supposed to be.  
@@ -22,7 +22,7 @@ Broadly speaking we write four different kinds of code, and the thought process 
 
 Starting from the most deep and deliberate and moving up towards user facing code which needs to be responsive to user feedback, the four big types of code are:
 
-### Runtime code
+### Runtime Code
 
 This is code that runs in a game, or in another environment where milliseconds actually count.
 
@@ -80,7 +80,7 @@ Library code resembles framework code in one way: it's still far away from the u
 
 Good libraries are easy to spot: they make it easy to do the right thing and hard to do the wrong thing.  [This talk](https://youtu.be/5tg1ONG18H8) is nominally about C++, but it's a good discussion of the ways api design and UX design are similar in any language.  Libraries should be designed for simplicity, consistency and lack of surprises.
 
-### Tools.
+### Tools
 
 Tools are the parts of our work that are visible to our users -- this is where the menus, buttons, dialogs and scripts go.  Tool code marshals the functionality from our frameworks and libraries into a user-friendly package that's easy to maintain and support.  
 
@@ -100,23 +100,23 @@ Tool code needs to:
     + UI always lives at the level of tools.
     + If code in a tool turns out to be generally useful, push it up into a new or existing library.  And then test it.
 
-
-Design standards [](#design_standards)
+<a id="design-standards"></a>
+Design Standards
 ================
 
 Again, this is not about _coding_ standards.  Design standards are about how we approach problems, not what the solution looks like written down.
 
 These sections are not really 'rules': they form a logical sequence.  TA code is a bit different from other programming problems -- even by software standards our world is chaotic and prone to change.  These guidelines are intended to help us build more stability into an environment that is prone to frequent, unplanned changes.  
 
-### Talk it out.
+### Talk It Out
 
 The first thing to do when starting a new project is _don't start writing._  Start by _talking_ to colleagues and customers to make sure you understand what you're being asked to do.  
 
-In that conversation, sketch out a general idea of how it ought to work.  For a big project that's probably an actual meeting, but for most work this could be a five minute conversation with the [understudy](#understudies) on the code.
+In that conversation, sketch out a general idea of how it ought to work.  For a big project that's probably an actual meeting, but for most work this could be a five minute conversation with the [understudy](#working-together) on the code.
 
 The goal of talking first is to make sure that (a) the job needs doing at all, (b) it hasn't already been solved by one of our colleagues and (c) our approach to the problem isn't going to cause problems down the road.
 
-### Start small.
+### Start Small
 
 It's tempting to try solving all future problems when writing code, particularly library or framework code.  
 
@@ -128,7 +128,7 @@ The hard truth of TA life is that the future we are envisioning may not ever arr
 
 An idea for how to solve a future problem is a great note to put into a comment or @todo.  But don't write future code until it serves a present need.  Long-lived library and especially framework code need to be more future-friendly.  However, even there it's a good idea to write as little code as is practical today.
 
-### Garden your code
+### Garden Your Code
 
 Code is alive. We want to guide its growth and trim it back when it gets overgrown.  An ongoing diet of small upgrades and improvements is better than letting code rot for years and then doing dramatic, drastic surgery on it. 
 Refactoring is just an ongoing part of maintenance --  not a scary dramatic intervention.
@@ -137,7 +137,7 @@ For this reaon, we want to be comfortable with refactoring as a regular part of 
 
 We also want to retire code that's not serving a purpose any longer.  It's all backed up, if we need it again some day we can find it again.  But leaving unused code around provides a temptation to borrow from it -- thereby to keep alive not just the one function that was borrowed, but all of its dependencies alive.
 
-### Test if you can
+### Test If You Can
 
 TA work makes it hard to completely embrace [test-driven development](https://news.codecademy.com/test-driven-development/).  Because a lot of TA work happens inside complex environments that we don't control from end to end, it's hard to hit 100% test coverage without a lot of work.
 
@@ -149,7 +149,7 @@ Another very important benefit of tests is that testing encourages good design. 
 
 Library and framework code should be tested.  Tools code -- with it's UI and scene dependencies is harder to test, but even there it's a good idea to design it in ways where testing is possible.
 
-### Good enough.
+### Good Enough
 
 This goes hand in hand with getting comfortable with refactoring as a regular event. Working through a problem is usually messy, and produces messy code. Every new tool is full of odd, one-off bits of code.  Getting a good understanding of the problem usually requires experimentation and that's OK.
 
@@ -157,7 +157,7 @@ However, once a tool moves into production it should be refactored into as clean
 
 What you write should get better over time.  It's very rare that you'll understand the whole problem set the first time. Good design will make it possible to add or extend the initial feature set in response to feedback and to the problems that only show up over time.  Again, being comfortable with refactoring makes it easier to adapt to new problems.  Every kind of coder struggles with the balance between 'just get it done' and the designing the perfectly general system that can be extended to all eventualities. The safest approach is to strike a middle ground: start small and improve, taking time to go back and rationalize the basic structure as you understand it better.
 
-###  Less is more
+###  Less Is More
 
 Starting small has another benefit as well. A wise man once said ["We hate code. We want to ship as little of it as possible"](https://www.youtube.com/watch?v=o9pEzgHorH0).  Not everything needs to be a class or a metaprogramming paradigm.  We ought to start with the simplest solution first, and add complexity when its called for.  Since we want to be comfortable with refactoring anyway there's no need to write a complex system until the simple system is failing to work.  
 
@@ -171,7 +171,7 @@ In keeping with that:
 There are situations where a higher-level approach adds more simplicity over the long haul.  These are cases for writing frameworks.  However these situations are _rare_.
 
 
-### Don't optimize on faith.  
+### Don't Optimize On Faith  
 
 Performance occupies a strange place in TA coding.  On the one hand, it's often a secondary consideration: the difference between a one-a-day button push that takes one second and one that takes two seconds is not really that important.  On the other hand, responsiveness is a critical part of how users will see your tools.  If the tool _feels_ slow it will be unpopular, even if it's useful.  
 
@@ -181,18 +181,19 @@ Trying to balance these conflicting needs isn't always easy, but when you do see
 
 Optimized code is a good thing -- when it's not a bad thing.  If the basic design is sound, it's usually possible to improve with optimization tricks.  But if the basic design is not sound, trying to speed it up with lots of micro-optimization is a lot of work that may or may not really pay off.  **Save the gimmicky stuff** for the last stage of stuff that's working, reliable and has already been checked against a profiler.
 
-Coding Standards[](#code_standards)
+<a id="coding-standards"></a>
+Coding Standards 
 ================
 
 This is the part of the doc that approximates a traditional coding standard.
 
-### General principles
+### General Principles
 
 Code formatting is not an interesting problem.  All standards rub somebody the wrong way.  But even a standard that you personally dislike is probably fine: it's job is too make your work more readable to _other_ people.  
 
 So: **suck it up and use the conventions of the environment you're in**. 
 
-### Write readable code.
+### Write Readable Code
 
 9/10th of the life of a line of code is in maintenance and bug-fixing.  Take the time to write clear, descriptive names for everything -- classes, functions, and variables. 
 
@@ -202,7 +203,7 @@ So:  **It's not done till it's properly named and commented.**  Comments for oth
 
 For precise advice what good names and comments look like, follow the guidelines in sections one of [The Art of Readable Code](https://www.amazon.com/Art-Readable-Code-Practical-Techniques/dp/0596802293).  We can adapt those rules for language flavor -- that is, use Unreal-style casing in C++ and underscored names in python -- but the principles are the same everywhere.  **Required reading.**
 
-### Write idiomatically. 
+### Write Idiomatically 
 
 Don't write Python in C++ or C# in Python.  Most of us like one language more than others, which is fine.  But code is a shared asset, and making your code readable and maintainable for other people means going with the flow of the language you are in.
 
@@ -223,8 +224,8 @@ Follow the [Unreal coding standards](https://docs.unrealengine.com/en-us/Program
 
 Follow [Pep-8](https://www.python.org/dev/peps/pep-0008/?).  We allow up to 120 characters wide (instead of the 80 characters in default pep-8) to avoid wasting time noodling on line breaks.  In Sublime Text use the [Anaconda](http://damnwidget.github.io/anaconda/) plugin for linting; in PyCharm use the default linter.  Use 4-space indentation.
 
-
-Working together [](#understudies)
+<a id="working-together"></a>
+Working Together
 ================
 As the department grows we need to do a better job of making sure we spread vital knowledge around. 
 
@@ -232,7 +233,8 @@ In order to do that, new features, systems or tools should always involve at lea
 
 The relationship looks like this:
 
-**Design review**  When the feature is first sketched out, the implementer will have to do some homework on how to approach the problem.  This could involve anything from reading a talking to customers to digging up research papers to reading code in the Unreal Engine.  When the implementer has a general idea of how to proceed, s/he should run it by the understudy to make sure that it makes sense.  The understudy should explicitly sign off on the general direction.  This could be as simple as 
+#### Design Review  
+When the feature is first sketched out, the implementer will have to do some homework on how to approach the problem.  This could involve anything from reading a talking to customers to digging up research papers to reading code in the Unreal Engine.  When the implementer has a general idea of how to proceed, s/he should run it by the understudy to make sure that it makes sense.  The understudy should explicitly sign off on the general direction.  This could be as simple as 
     
 > "Hey X -- I think I'm going to tackle this by creating a map of CharacterAssets to ClothingAssets and storing that as an Unreal DataTable.  Users can open that in the editor and add their annotations that way" 
 
@@ -242,9 +244,11 @@ or it could involve an actual whiteboarding session.  The point is _not_ to enfo
 
 Understudies can, and should, remind implementers if there is existing functionality that can be reused.  Less is more!
 
-**Code review**  As the feature or system progresses, understudies should review major checkins.  We'll need to work out the right cadence, it's too much to expect that every checkin will be reviewed by another person.  But significant waypoints in the evolution of the feature should be reviewed. The goal is that the finished code is at least somewhat familiar to at least two people at all times.  An important part of the understudy's review process will be pointing out places where the code needs comments or is hard to follow, and to encourage attention to our general design standards. 
+#### Code Review
+As the feature or system progresses, understudies should review major checkins.  We'll need to work out the right cadence, it's too much to expect that every checkin will be reviewed by another person.  But significant waypoints in the evolution of the feature should be reviewed. The goal is that the finished code is at least somewhat familiar to at least two people at all times.  An important part of the understudy's review process will be pointing out places where the code needs comments or is hard to follow, and to encourage attention to our general design standards. 
 
-**Wrap up** Nothing is done unless it's readably commented (for other coders) and documented (for end users).  The final documentation pass should fall on the understudy, with input and review from the implementer. This is important for making sure that the system makes sense to at least two people.
+#### Wrap Up
+Nothing is done unless it's readably commented (for other coders) and documented (for end users).  The final documentation pass should fall on the understudy, with input and review from the implementer. This is important for making sure that the system makes sense to at least two people.
 
 In many cases -- particularly for more complex jobs -- the understudy will also be working on the same code.  In cases like that the two roles should basically be reversed as needed:  A understudies B's work and vice-versa.  
 


### PR DESCRIPTION
Named anchor link target syntax edited/added for all main headings.
Named anchor links edited to have consistent casing (kebab style was chosen for having consistent functionality between multiple viewers, underscore case ended up not working in some contexts).

Proposing upper-casing and no periods for all headings and sub-headings.

Proposing h4s for the Working Together subsections.

Closes #2